### PR TITLE
WOOR-98/ atoms/Input, molecules/TextInput, hooks/useForm 구현

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,10 +13,9 @@ module.exports = {
   },
   webpackFinal: async (config) => {
     const alias = {
-      '@components': path.resolve(__dirname, 'components'),
-      '@pages': path.resolve(__dirname, 'pages'),
-      '@hooks': path.resolve(__dirname, 'hooks'),
-      '@utils': path.resolve(__dirname, 'utils'),
+      components: path.resolve(__dirname, '../components'),
+      '@pages': path.resolve(__dirname, '../pages'),
+      public: path.resolve(__dirname, '../public'),
     };
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
 import theme from '../styles/theme';
 import GlobalStyle from '../styles/GlobalStyle';
+import * as NextImage from 'next/image';
 
 export const decorators = [
   (Story) => (
@@ -20,3 +21,11 @@ export const parameters = {
     },
   },
 };
+
+// for stroybook next/image
+const OriginalNextImage = NextImage.default;
+
+Object.defineProperty(NextImage, 'default', {
+  configurable: true,
+  value: (props) => <OriginalNextImage {...props} unoptimized />,
+});

--- a/components/atoms/Input/Input.styles.ts
+++ b/components/atoms/Input/Input.styles.ts
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Input = styled.input``;

--- a/components/atoms/Input/Input.tsx
+++ b/components/atoms/Input/Input.tsx
@@ -6,7 +6,6 @@ interface IInputProps {
   value?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  deleteAll?: () => void;
 }
 
 function Input({
@@ -15,7 +14,6 @@ function Input({
   value,
   placeholder,
   onChange,
-  deleteAll,
   ...styles
 }: IInputProps) {
   return (

--- a/components/atoms/Input/Input.tsx
+++ b/components/atoms/Input/Input.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect } from 'react';
 import * as S from './Input.styles';
 
 interface IInputProps {
   name?: string;
   type?: string;
-  defaultValue?: string;
+  value?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   deleteAll?: () => void;
@@ -13,35 +12,19 @@ interface IInputProps {
 function Input({
   name,
   type,
-  defaultValue,
+  value,
   placeholder,
   onChange,
   deleteAll,
   ...styles
 }: IInputProps) {
-  const [inputValue, setInputValue] = useState('');
-
-  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-    if (onChange) onChange(e);
-  };
-
-  const deleteAllInput = () => {
-    setInputValue('');
-    // deleteAll(name);
-  };
-
-  useEffect(() => {
-    if (defaultValue) setInputValue(defaultValue);
-  }, [defaultValue]);
-
   return (
     <S.Input
       name={name}
       type={type}
       placeholder={placeholder}
-      value={inputValue}
-      onChange={onChangeInput}
+      value={value}
+      onChange={onChange}
       {...styles}
     />
   );

--- a/components/atoms/Input/Input.tsx
+++ b/components/atoms/Input/Input.tsx
@@ -7,6 +7,7 @@ interface IInputProps {
   defaultValue?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  deleteAll?: () => void;
 }
 
 function Input({
@@ -15,6 +16,7 @@ function Input({
   defaultValue,
   placeholder,
   onChange,
+  deleteAll,
   ...styles
 }: IInputProps) {
   const [inputValue, setInputValue] = useState('');
@@ -22,6 +24,11 @@ function Input({
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
     if (onChange) onChange(e);
+  };
+
+  const deleteAllInput = () => {
+    setInputValue('');
+    // deleteAll(name);
   };
 
   useEffect(() => {

--- a/components/atoms/Input/Input.tsx
+++ b/components/atoms/Input/Input.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import * as S from './Input.styles';
+
+interface IInputProps {
+  name?: string;
+  type?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+function Input({
+  name,
+  type,
+  defaultValue,
+  placeholder,
+  onChange,
+  ...styles
+}: IInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    if (onChange) onChange(e);
+  };
+
+  useEffect(() => {
+    if (defaultValue) setInputValue(defaultValue);
+  }, [defaultValue]);
+
+  return (
+    <S.Input
+      name={name}
+      type={type}
+      placeholder={placeholder}
+      value={inputValue}
+      onChange={onChangeInput}
+      {...styles}
+    />
+  );
+}
+
+Input.defaultProps = {
+  type: 'text',
+};
+
+export default Input;

--- a/components/atoms/Input/index.ts
+++ b/components/atoms/Input/index.ts
@@ -1,0 +1,3 @@
+import Input from './Input';
+
+export default Input;

--- a/components/atoms/Input/index.ts
+++ b/components/atoms/Input/index.ts
@@ -1,3 +1,1 @@
-import Input from './Input';
-
-export default Input;
+export { default as Input } from './Input';

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,9 +1,8 @@
 // atoms
-export { Button } from './atoms/Button';
-export { Profile } from '@components/atoms/Profile';
-
+export { default as Button } from './atoms/Button';
+export { default as Input } from './atoms/Input';
 // molecules
-export { NavBar } from '@components/organisms/NavBar';
+export { default as TextInput } from './molecules/TextInput';
 
 // organisms
 export { LoggedInSection } from '@components/molecules/LoggedInSection';

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,11 +1,14 @@
 // atoms
-export { default as Button } from './atoms/Button';
+export { Button } from './atoms/Button';
 export { default as Input } from './atoms/Input';
+export { Profile } from './atoms/Profile';
+
 // molecules
 export { default as TextInput } from './molecules/TextInput';
 
 // organisms
 export { LoggedInSection } from '@components/molecules/LoggedInSection';
+export { NavBar } from '@components/organisms/NavBar';
 
 // templates
 export { Layout } from '@components/templates/Layout';

--- a/components/molecules/TextInput/TextInput.stories.tsx
+++ b/components/molecules/TextInput/TextInput.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import styled from '@emotion/styled';
 import TextInput from './TextInput';
 
 export default {
@@ -7,6 +8,14 @@ export default {
   argTypes: {},
 } as ComponentMeta<typeof TextInput>;
 
+const Wrapper = styled.div`
+  width: 366px;
+`;
+
 export const Default: ComponentStory<typeof TextInput> = (args) => {
-  return <TextInput {...args} />;
+  return (
+    <Wrapper>
+      <TextInput {...args} />
+    </Wrapper>
+  );
 };

--- a/components/molecules/TextInput/TextInput.stories.tsx
+++ b/components/molecules/TextInput/TextInput.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import TextInput from './TextInput';
+
+export default {
+  title: 'Components/Molecules/TextInput',
+  component: TextInput,
+  argTypes: {},
+} as ComponentMeta<typeof TextInput>;
+
+export const Default: ComponentStory<typeof TextInput> = (args) => {
+  return <TextInput {...args} />;
+};

--- a/components/molecules/TextInput/TextInput.styles.ts
+++ b/components/molecules/TextInput/TextInput.styles.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import Input from '../../atoms/Input';
+
+export const TextInputWrapper = styled.div`
+  flex: 1;
+  border-radius: 10px;
+  padding: 13px 16px;
+`;
+
+export const TextInput = styled(Input)`
+  //color: ${({ theme }) => theme.colors.black};
+`;
+
+export const DeleteButton = styled(Image)``;

--- a/components/molecules/TextInput/TextInput.styles.ts
+++ b/components/molecules/TextInput/TextInput.styles.ts
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
 import Image from 'next/image';
+import styled from '@emotion/styled';
 import Input from '../../atoms/Input';
 
 export const TextInputWrapper = styled.div`

--- a/components/molecules/TextInput/TextInput.styles.ts
+++ b/components/molecules/TextInput/TextInput.styles.ts
@@ -3,13 +3,24 @@ import Image from 'next/image';
 import Input from '../../atoms/Input';
 
 export const TextInputWrapper = styled.div`
+  display: flex;
   flex: 1;
   border-radius: 10px;
+  border: 2px solid ${({ theme }) => theme.colors.gray};
   padding: 13px 16px;
 `;
 
 export const TextInput = styled(Input)`
-  //color: ${({ theme }) => theme.colors.black};
+  outline-style: none;
+  border: 0;
+  outline: 0;
+  width: 98%;
+  font-size: 16px;
+  font-weight: 600;
 `;
 
-export const DeleteButton = styled(Image)``;
+export const DeleteButton = styled(Image)`
+  cursor: pointer;
+  position: absolute;
+  right: 16px;
+`;

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -1,29 +1,47 @@
+import { useState } from 'react';
 import deleteIcon from 'public/image/delete.svg';
 import * as S from './TextInput.styles';
 
 interface ITextInputProps {
-  onChange?: () => void;
   name: string;
   placeholder: string;
+  onChange?: () => void;
+  deleteAll?: (name: string) => void;
 }
 
 function TextInput({
   onChange,
   name,
   placeholder,
+  deleteAll,
   ...styles
 }: ITextInputProps) {
-  const deleteAll = (name: string) => {};
+  const [inputValue, setInputValue] = useState('');
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    if (onChange) onChange();
+  };
+
+  const onClickDeleteButton = () => {
+    setInputValue('');
+    if (deleteAll) deleteAll(name);
+  };
 
   return (
     <S.TextInputWrapper {...styles}>
-      <S.TextInput onChange={onChange} name={name} placeholder={placeholder} />
+      <S.TextInput
+        name={name}
+        value={inputValue}
+        placeholder={placeholder}
+        onChange={onChangeInput}
+      />
       <S.DeleteButton
         src={deleteIcon}
         alt="Delete All"
         width={16}
         height={16}
-        onClick={() => deleteAll(name)}
+        onClick={onClickDeleteButton}
       />
     </S.TextInputWrapper>
   );

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -1,0 +1,23 @@
+import deleteIcon from 'public/image/delete.svg';
+import * as S from './TextInput.styles';
+
+interface ITextInputProps {
+  onChange?: () => void;
+  errors?: string;
+}
+
+function TextInput({ onChange, errors, ...styles }: ITextInputProps) {
+  return (
+    <S.TextInputWrapper {...styles}>
+      <S.TextInput onChange={onChange} />
+      <S.DeleteButton
+        src={deleteIcon}
+        alt="Delete All"
+        width="16px"
+        height="16px"
+      />
+    </S.TextInputWrapper>
+  );
+}
+
+export default TextInput;

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -16,7 +16,7 @@ function TextInput({
   deleteAll,
   ...styles
 }: ITextInputProps) {
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState<string>('');
 
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -3,18 +3,27 @@ import * as S from './TextInput.styles';
 
 interface ITextInputProps {
   onChange?: () => void;
-  errors?: string;
+  name: string;
+  placeholder: string;
 }
 
-function TextInput({ onChange, errors, ...styles }: ITextInputProps) {
+function TextInput({
+  onChange,
+  name,
+  placeholder,
+  ...styles
+}: ITextInputProps) {
+  const deleteAll = (name: string) => {};
+
   return (
     <S.TextInputWrapper {...styles}>
-      <S.TextInput onChange={onChange} />
+      <S.TextInput onChange={onChange} name={name} placeholder={placeholder} />
       <S.DeleteButton
         src={deleteIcon}
         alt="Delete All"
-        width="16px"
-        height="16px"
+        width={16}
+        height={16}
+        onClick={() => deleteAll(name)}
       />
     </S.TextInputWrapper>
   );

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -3,16 +3,18 @@ import deleteIcon from 'public/image/delete.svg';
 import * as S from './TextInput.styles';
 
 interface ITextInputProps {
-  name: string;
-  placeholder: string;
+  name?: string;
+  type?: string;
+  placeholder?: string;
   onChange?: () => void;
   deleteAll?: (name: string) => void;
 }
 
 function TextInput({
-  onChange,
   name,
+  type,
   placeholder,
+  onChange,
   deleteAll,
   ...styles
 }: ITextInputProps) {
@@ -25,15 +27,16 @@ function TextInput({
 
   const onClickDeleteButton = () => {
     setInputValue('');
-    if (deleteAll) deleteAll(name);
+    if (deleteAll && name) deleteAll(name);
   };
 
   return (
     <S.TextInputWrapper {...styles}>
       <S.TextInput
         name={name}
-        value={inputValue}
+        type={type}
         placeholder={placeholder}
+        value={inputValue}
         onChange={onChangeInput}
       />
       <S.DeleteButton

--- a/components/molecules/TextInput/index.ts
+++ b/components/molecules/TextInput/index.ts
@@ -1,0 +1,3 @@
+import TextInput from './TextInput';
+
+export default TextInput;

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 interface IUseForm<T> {
   initialValues: T;
@@ -27,9 +27,12 @@ const useForm = <T>({ initialValues, onSubmit, validate }: IUseForm<T>) => {
     setIsLoading(false);
   };
 
-  const removeAll = (name: string) => {
-    setValues({ ...values, [name]: '' });
-  };
+  const removeAll = useCallback(
+    (name: string) => {
+      setValues({ ...values, [name]: '' });
+    },
+    [values],
+  );
 
   return {
     values,

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface IUseForm<T> {
+  initialValues: T;
+  onSubmit: (values: T) => void;
+  validate: (values: T) => object;
+}
+
+const useForm = <T>({ initialValues, onSubmit, validate }: IUseForm<T>) => {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setValues({ ...values, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    setIsLoading(true);
+    e.preventDefault();
+    const newErrors = validate ? validate(values) : {};
+    if (Object.keys(newErrors).length === 0) {
+      await onSubmit(values);
+    }
+    setErrors(newErrors);
+    setIsLoading(false);
+  };
+
+  const removeAll = (name: string) => {
+    setValues({ ...values, [name]: '' });
+  };
+
+  return {
+    values,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit,
+    removeAll,
+  };
+};
+
+export default useForm;

--- a/hooks/useForm/index.ts
+++ b/hooks/useForm/index.ts
@@ -1,0 +1,1 @@
+export { default as useGeolocation } from './useForm';

--- a/hooks/useForm/index.ts
+++ b/hooks/useForm/index.ts
@@ -1,1 +1,1 @@
-export { default as useGeolocation } from './useForm';
+export { default as useForm } from './useForm';

--- a/hooks/useForm/useForm.ts
+++ b/hooks/useForm/useForm.ts
@@ -6,7 +6,7 @@ interface IUseForm<T> {
   validate: (values: T) => object;
 }
 
-const useForm = <T>({ initialValues, onSubmit, validate }: IUseForm<T>) => {
+function useForm<T>({ initialValues, onSubmit, validate }: IUseForm<T>) {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
@@ -42,6 +42,6 @@ const useForm = <T>({ initialValues, onSubmit, validate }: IUseForm<T>) => {
     handleSubmit,
     removeAll,
   };
-};
+}
 
 export default useForm;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "storybook": "start-storybook -p 6006 -s ./public",
+    "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,0 +1,10 @@
+import { Button, TextInput } from 'components';
+
+export default function Test() {
+  return (
+    <div>
+      <TextInput />
+      <Button>Test</Button>
+    </div>
+  );
+}

--- a/public/image/delete.svg
+++ b/public/image/delete.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9.99968" cy="10.0005" r="9.16667" fill="#ECECEC"/>
+<path d="M7.05373 12.9463L12.9463 7.05371" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M7.05373 7.05373L12.9463 12.9463" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷
![image](https://user-images.githubusercontent.com/50645183/182017880-1b6ca1e7-f403-4311-8859-bde0406a72e1.png)

### 내용
- [x] atoms/Input 구현
- [x] molecules/TextInput 구현
- [x]  hooks/useForm 구현

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- ```atoms/Input``` 은 말그대로 atom이므로 단순한 HTML 태그인 input의 역할만 하는 컴포넌트 입니다.
- molecule로 가면서 기존 ```atoms/Input```을 활용한 TextInput을 구성했습니다.
  - input값을 useState로 관리하면서 구상 초기에는 atom인 ```Input```에 두었으나, 내용 삭제 버튼과 useForm hook과의 연계성을 고려했을 때 불필요한 props를 너무 많이 내려주는 것 같아 상위 컴포넌트인 ```TextInput```에서 ```value, onChange, placeholder, name``` 이렇게 꼭 필요한 props를 내려주도록 구조를 바꿨습니다.

![image](https://user-images.githubusercontent.com/50645183/182018101-2c6dce91-dea5-4420-8f44-7d7ee2894c35.png)
![image](https://user-images.githubusercontent.com/50645183/182018234-60fd91fb-8c0d-488e-942b-5305f2fa38ea.png)

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 아직 useForm hook과 Input과의 연계를 정확히 테스팅 해보진 않았습니다.
- 추후에 ```CalenderInput```과 ```ProfileEditForm``` 등을 구성하며 디테일적인 측면을 더 보완해야할 것 같습니다.

