### PR TITLE
WOOR-146/포스트 페이지 공통 레이아웃

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -21,3 +21,4 @@ export { NavBar } from 'components/organisms/NavBar';
 
 // templates
 export { Layout } from 'components/templates/Layout';
+export { PostTemplate } from 'components/templates/PostTemplate';

--- a/components/templates/Layout/Layout.styles.tsx
+++ b/components/templates/Layout/Layout.styles.tsx
@@ -14,7 +14,7 @@ export const Container = styled.div`
 export const Wrapper = styled.main<{ isLoggedIn: boolean }>`
   width: 100%;
   max-width: 75rem;
-  height: 100%;
+  flex: 1;
 
   ${({ isLoggedIn }) => isLoggedIn && `margin-top: 5rem;`})}
 

--- a/components/templates/PostTemplate/PostTemplate.styles.tsx
+++ b/components/templates/PostTemplate/PostTemplate.styles.tsx
@@ -1,21 +1,24 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.section`
-  width: 100%;
-  height: 100%;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
 
+  width: 100%;
+  height: 100%;
+
   gap: 1rem;
-  padding: 32px 24px;
+  padding: 2rem 1.5rem;
 
   box-sizing: border-box;
 `;
 
 export const ImageSection = styled.div`
   background: red;
+  overflow: auto;
 `;
 
 export const ContentSecion = styled.div`
   background: blue;
+  overflow: auto;
 `;

--- a/components/templates/PostTemplate/PostTemplate.styles.tsx
+++ b/components/templates/PostTemplate/PostTemplate.styles.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.section`
+  width: 100%;
+  height: 100%;
+`;
+
+export const ImageSection = styled.div`
+  flex: 1;
+  background: red;
+`;
+
+export const ContentSecion = styled.div`
+  flex: 1;
+  background: blue;
+`;

--- a/components/templates/PostTemplate/PostTemplate.styles.tsx
+++ b/components/templates/PostTemplate/PostTemplate.styles.tsx
@@ -18,7 +18,7 @@ export const ImageSection = styled.div`
   overflow: auto;
 `;
 
-export const ContentSecion = styled.div`
+export const ContentSection = styled.div`
   background: blue;
   overflow: auto;
 `;

--- a/components/templates/PostTemplate/PostTemplate.styles.tsx
+++ b/components/templates/PostTemplate/PostTemplate.styles.tsx
@@ -3,14 +3,19 @@ import styled from '@emotion/styled';
 export const Container = styled.section`
   width: 100%;
   height: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+
+  gap: 1rem;
+  padding: 32px 24px;
+
+  box-sizing: border-box;
 `;
 
 export const ImageSection = styled.div`
-  flex: 1;
   background: red;
 `;
 
 export const ContentSecion = styled.div`
-  flex: 1;
   background: blue;
 `;

--- a/components/templates/PostTemplate/PostTemplate.tsx
+++ b/components/templates/PostTemplate/PostTemplate.tsx
@@ -10,7 +10,7 @@ export function PostTemplate({
   return (
     <S.Container>
       <S.ImageSection>{imageSection}</S.ImageSection>
-      <S.ContentSecion>{contentSection}</S.ContentSecion>
+      <S.ContentSection>{contentSection}</S.ContentSection>
     </S.Container>
   );
 }

--- a/components/templates/PostTemplate/PostTemplate.tsx
+++ b/components/templates/PostTemplate/PostTemplate.tsx
@@ -1,0 +1,16 @@
+import * as S from './PostTemplate.styles';
+
+export function PostTemplate({
+  imageSection,
+  contentSection,
+}: {
+  imageSection: React.ReactNode;
+  contentSection: React.ReactNode;
+}) {
+  return (
+    <S.Container>
+      <S.ImageSection>{imageSection}</S.ImageSection>
+      <S.ContentSecion>{contentSection}</S.ContentSecion>
+    </S.Container>
+  );
+}

--- a/components/templates/PostTemplate/index.ts
+++ b/components/templates/PostTemplate/index.ts
@@ -1,0 +1,1 @@
+export { PostTemplate } from './PostTemplate';

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,10 +1,7 @@
-import { Button, TextInput } from 'components';
+import { Button, PostTemplate } from 'components';
 
 export default function Test() {
   return (
-    <div>
-      <TextInput />
-      <Button>Test</Button>
-    </div>
+    <PostTemplate imageSection={<div>A</div>} contentSection={<div>B</div>} />
   );
 }

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,4 +1,4 @@
-import { Button, PostTemplate } from 'components';
+import { PostTemplate } from 'components';
 
 export default function Test() {
   return (

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,7 +1,10 @@
-import { PostTemplate } from 'components';
+import { PostTemplate, ImageViewer } from 'components';
 
 export default function Test() {
   return (
-    <PostTemplate imageSection={<div>A</div>} contentSection={<div>B</div>} />
+    <PostTemplate
+      imageSection={<ImageViewer />}
+      contentSection={<div>B</div>}
+    />
   );
 }


### PR DESCRIPTION
## 📌 PR 설명

- [x] 포스트 페이지 공통 레이아웃 처리

### 스크린 샷

<img width="1439" alt="스크린샷 2022-08-03 오전 10 25 43" src="https://user-images.githubusercontent.com/60822846/182504169-d31dfe80-ab50-4cb1-b2a1-e23d4712cf78.png">


### 내용

이 부분은 템플릿으로 분리하였습니다.

```javascript
import * as S from './PostTemplate.styles';

export function PostTemplate({
  imageSection,
  contentSection,
}: {
  imageSection: React.ReactNode;
  contentSection: React.ReactNode;
}) {
  return (
    <S.Container>
      <S.ImageSection>{imageSection}</S.ImageSection>
      <S.ContentSecion>{contentSection}</S.ContentSecion>
    </S.Container>
  );
}
```
위와 같은 방식으로 `ReactNode`를 2개 받고 해당 레이아웃을 보여주는 형식입니다.

사용 방법은 `pages`에서 만든 템플릿을 정의하고 하부 내용에 보여질 컨텐츠들인 organisms를 넣어주면 됩니다.

```javascript
  return (
    <PostTemplate imageSection={<div>A</div>} contentSection={<div>B</div>} />
  );
```
## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### 🚀 연관된 이슈
