### PR TITLE
WOOR-211 / refactor : 메인페이지에서 사용되는 types 추상화

### DIFF
--- a/components/molecules/CoupleProfile/CoupleProfile.styles.tsx
+++ b/components/molecules/CoupleProfile/CoupleProfile.styles.tsx
@@ -18,7 +18,7 @@ export const EachProfileContainer = styled.div`
   min-height: 176px;
 `;
 
-export const Nickname = styled.div`
+export const NickName = styled.div`
   width: 80%;
   height: 50px;
   padding-top: 16px;
@@ -52,7 +52,7 @@ export const DDay = styled.div`
   color: ${({ theme }) => theme.colors.white};
 `;
 
-export const StartingDate = styled.div`
+export const StartDate = styled.div`
   text-align: center;
   font-size: 14px;
   font-weight: 500;

--- a/components/molecules/CoupleProfile/CoupleProfile.tsx
+++ b/components/molecules/CoupleProfile/CoupleProfile.tsx
@@ -12,7 +12,7 @@ function EachProfile({ nickName, profileImagePath }: ICoupleUserProps) {
         path={profileImagePath}
         isLink={false}
       />
-      <S.Nickname>{nickName}</S.Nickname>
+      <S.NickName>{nickName}</S.NickName>
     </S.EachProfileContainer>
   );
 }
@@ -23,9 +23,9 @@ function CoupleInfo({ startDate }: IStartDateProps) {
   return (
     <S.CoupleInfoContainer>
       <S.DDay>{`D + ${calculatedDDay}`}</S.DDay>
-      <S.StartingDate>{`
+      <S.StartDate>{`
       ${startDate}
-      `}</S.StartingDate>
+      `}</S.StartDate>
     </S.CoupleInfoContainer>
   );
 }

--- a/components/molecules/CoupleProfile/CoupleProfile.tsx
+++ b/components/molecules/CoupleProfile/CoupleProfile.tsx
@@ -1,48 +1,46 @@
+import { ICoupleUserProps, IStartDateProps, ICoupleProfileProps } from 'types';
 import { Profile } from 'components';
 import { calculatingDDay } from 'utils';
 import * as S from './CoupleProfile.styles';
 
-interface INickname {
-  nickname: string | null;
-}
-interface ICoupleStartingDate {
-  coupleStartingDate: string;
-}
-interface ICoupleProfileProps extends INickname, ICoupleStartingDate {
-  coupleNickname: string;
-}
-
-function EachProfile({ nickname }: INickname) {
+function EachProfile({ nickName, profileImagePath }: ICoupleUserProps) {
   return (
     <S.EachProfileContainer>
-      <Profile width={128} height={128} path={null} isLink={false} />
-      <S.Nickname>{nickname}</S.Nickname>
+      <Profile
+        width={128}
+        height={128}
+        path={profileImagePath}
+        isLink={false}
+      />
+      <S.Nickname>{nickName}</S.Nickname>
     </S.EachProfileContainer>
   );
 }
 
-function CoupleInfo({ coupleStartingDate }: ICoupleStartingDate) {
-  const calculatedDDay = calculatingDDay(coupleStartingDate);
+function CoupleInfo({ startDate }: IStartDateProps) {
+  const calculatedDDay = calculatingDDay(startDate);
 
   return (
     <S.CoupleInfoContainer>
       <S.DDay>{`D + ${calculatedDDay}`}</S.DDay>
       <S.StartingDate>{`
-      ${coupleStartingDate}
+      ${startDate}
       `}</S.StartingDate>
     </S.CoupleInfoContainer>
   );
 }
-export function CoupleProfile({
-  nickname,
-  coupleNickname,
-  coupleStartingDate,
-}: ICoupleProfileProps) {
+export function CoupleProfile({ me, you, startDate }: ICoupleProfileProps) {
   return (
     <S.Container>
-      <EachProfile nickname={nickname} />
-      <CoupleInfo coupleStartingDate={coupleStartingDate} />
-      <EachProfile nickname={coupleNickname} />
+      <EachProfile
+        nickName={me.nickName}
+        profileImagePath={me.profileImagePath}
+      />
+      <CoupleInfo startDate={startDate} />
+      <EachProfile
+        nickName={you.nickName}
+        profileImagePath={you.profileImagePath}
+      />
     </S.Container>
   );
 }

--- a/components/molecules/MainThumbnailList/MainThumbnailList.tsx
+++ b/components/molecules/MainThumbnailList/MainThumbnailList.tsx
@@ -1,25 +1,30 @@
+import { IThumbnailCardProps } from 'types';
 import * as S from './MainThumbnailList.styles';
-
-export interface IThumbnailCardProps {
-  postId: string;
-  postThumbnailPath: string;
-  title: string;
-  createDate: string;
-}
 
 function ThumbnailCard({
   postId,
   postThumbnailPath,
   title,
   createDate,
+  latitude,
+  longitude,
 }: IThumbnailCardProps) {
   const onClick = (_postId: string) => {
     // postId별 라우팅 관련 로직 추가 예정
     alert(`${_postId}를 클릭하셨군여 (๑•̀ㅂ•́)و✧`);
   };
 
+  const coordinate = {
+    latitude: latitude || null,
+    longitude: longitude || null,
+  };
+
   return (
-    <S.CardContainer url={postThumbnailPath} onClick={() => onClick(postId)}>
+    <S.CardContainer
+      url={postThumbnailPath}
+      data-coordinate={coordinate}
+      onClick={() => onClick(postId)}
+    >
       <div>
         <S.Title>{title}</S.Title>
         <S.CreateDate>{createDate}</S.CreateDate>
@@ -35,15 +40,26 @@ export function MainThumbnailList({
 }) {
   return (
     <S.MainThumbnailListContainer>
-      {postList.map(({ postId, postThumbnailPath, title, createDate }) => (
-        <ThumbnailCard
-          key={postId}
-          postId={postId}
-          postThumbnailPath={postThumbnailPath}
-          title={title}
-          createDate={createDate}
-        />
-      ))}
+      {postList.map(
+        ({
+          postId,
+          postThumbnailPath,
+          title,
+          createDate,
+          latitude,
+          longitude,
+        }) => (
+          <ThumbnailCard
+            key={postId}
+            postId={postId}
+            postThumbnailPath={postThumbnailPath}
+            title={title}
+            createDate={createDate}
+            latitude={latitude}
+            longitude={longitude}
+          />
+        ),
+      )}
     </S.MainThumbnailListContainer>
   );
 }

--- a/components/molecules/MainThumbnailList/MainThumbnailList.tsx
+++ b/components/molecules/MainThumbnailList/MainThumbnailList.tsx
@@ -6,25 +6,14 @@ function ThumbnailCard({
   postThumbnailPath,
   title,
   createDate,
-  latitude,
-  longitude,
 }: IThumbnailCardProps) {
   const onClick = (_postId: string) => {
     // postId별 라우팅 관련 로직 추가 예정
     alert(`${_postId}를 클릭하셨군여 (๑•̀ㅂ•́)و✧`);
   };
 
-  const coordinate = {
-    latitude: latitude || null,
-    longitude: longitude || null,
-  };
-
   return (
-    <S.CardContainer
-      url={postThumbnailPath}
-      data-coordinate={coordinate}
-      onClick={() => onClick(postId)}
-    >
+    <S.CardContainer url={postThumbnailPath} onClick={() => onClick(postId)}>
       <div>
         <S.Title>{title}</S.Title>
         <S.CreateDate>{createDate}</S.CreateDate>
@@ -40,26 +29,15 @@ export function MainThumbnailList({
 }) {
   return (
     <S.MainThumbnailListContainer>
-      {postList.map(
-        ({
-          postId,
-          postThumbnailPath,
-          title,
-          createDate,
-          latitude,
-          longitude,
-        }) => (
-          <ThumbnailCard
-            key={postId}
-            postId={postId}
-            postThumbnailPath={postThumbnailPath}
-            title={title}
-            createDate={createDate}
-            latitude={latitude}
-            longitude={longitude}
-          />
-        ),
-      )}
+      {postList.map(({ postId, postThumbnailPath, title, createDate }) => (
+        <ThumbnailCard
+          key={postId}
+          postId={postId}
+          postThumbnailPath={postThumbnailPath}
+          title={title}
+          createDate={createDate}
+        />
+      ))}
     </S.MainThumbnailListContainer>
   );
 }

--- a/components/molecules/MainThumbnailList/index.ts
+++ b/components/molecules/MainThumbnailList/index.ts
@@ -1,2 +1,1 @@
 export { MainThumbnailList } from './MainThumbnailList';
-export type { IThumbnailCardProps } from './MainThumbnailList';

--- a/components/organisms/MainSidebar/MainSidebar.tsx
+++ b/components/organisms/MainSidebar/MainSidebar.tsx
@@ -1,31 +1,13 @@
+import { IMainSidebarProps } from 'types';
 import { CoupleProfile, MainSearchBar, MainThumbnailList } from 'components';
-import { IThumbnailCardProps } from 'components/molecules/MainThumbnailList';
 import * as S from './MainSidebar.styles';
 
-interface IProfile {
-  profileImagePath: string;
-  nickname: string;
-}
-
-export interface IMainSidebarProps {
-  coupleData: {
-    startDate: string;
-    me: IProfile;
-    you: IProfile;
-  };
-  postList: IThumbnailCardProps[];
-}
-
 export function MainSidebar({ coupleData, postList }: IMainSidebarProps) {
-  const { startDate, me, you } = coupleData;
+  const { me, you, startDate } = coupleData;
 
   return (
     <S.Container>
-      <CoupleProfile
-        nickname={me.nickname}
-        coupleNickname={you.nickname}
-        coupleStartingDate={startDate}
-      />
+      <CoupleProfile me={me} you={you} startDate={startDate} />
       <MainSearchBar />
       <MainThumbnailList postList={postList} />
     </S.Container>

--- a/components/organisms/MainSidebar/index.ts
+++ b/components/organisms/MainSidebar/index.ts
@@ -1,2 +1,1 @@
 export { MainSidebar } from './MainSidebar';
-export type { IMainSidebarProps } from './MainSidebar';

--- a/components/templates/MainPageTemplate/MainPageTemplate.tsx
+++ b/components/templates/MainPageTemplate/MainPageTemplate.tsx
@@ -1,31 +1,9 @@
+import { IMainPageTemplateProps } from 'types';
 import { Map, MainSidebar } from 'components';
 import * as S from './MainPageTemplate.styles';
 
 // 지금 Dependency cycle 에러가 나서 types import를 다 빼고 일일히 하드코딩 해 놓은 상태입니다. 해당 커밋 이후에 관련 types는 모두 추상화해서 types 폴더에 따로 빼 놓을 계획입니다.
 
-interface IMainPageTemplateProps {
-  coupleData: {
-    startDate: string;
-    me: {
-      profileImagePath: string;
-      nickname: string;
-    };
-    you: {
-      profileImagePath: string;
-      nickname: string;
-    };
-  };
-  postList: {
-    postId: string;
-    postThumbnailPath: string;
-    title: string;
-    createDate: string;
-  }[];
-  coordinate: {
-    lat: number;
-    lng: number;
-  };
-}
 export function MainPageTemplate({
   coupleData,
   postList,
@@ -41,8 +19,8 @@ export function MainPageTemplate({
           width="100%"
           height="100%"
           center={{
-            lat: coordinate.lat,
-            lng: coordinate.lng,
+            lat: coordinate.latitude,
+            lng: coordinate.longitude,
           }}
         />
       </S.MapContainer>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,12 +7,12 @@ function Home() {
     const dummyData = {
       startDate: '2021-11-19',
       me: {
-        profileImagePath: '#',
-        nickname: 'myname',
+        profileImagePath: null,
+        nickName: 'myname',
       },
       you: {
-        profileImagePath: '#',
-        nickname: 'yourname',
+        profileImagePath: null,
+        nickName: 'yourname',
       },
     };
     return dummyData;
@@ -107,7 +107,7 @@ function Home() {
     <MainPageTemplate
       coupleData={dummyCoupleData}
       postList={dummyPostListData}
-      coordinate={{ lat, lng }}
+      coordinate={{ latitude: lat, longitude: lng }}
     />
   );
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,3 +20,11 @@ export type {
   HandleChangeTypes,
 } from 'types/post';
 export type { IButtonStyleProps } from 'types/button';
+export type {
+  ICoupleUserProps,
+  IStartDateProps,
+  ICoupleProfileProps,
+  IThumbnailCardProps,
+  IMainSidebarProps,
+  IMainPageTemplateProps,
+} from 'types/mainPage';

--- a/types/mainPage.d.ts
+++ b/types/mainPage.d.ts
@@ -1,0 +1,36 @@
+import { ImageProps } from 'next/image';
+
+export interface ICoupleUserProps {
+  profileImagePath: string | null;
+  nickName: string;
+}
+
+export interface IStartDateProps {
+  startDate: string;
+}
+
+export interface ICoupleProfileProps extends IStartDateProps {
+  me: ICoupleUserProps;
+  you: ICoupleUserProps;
+}
+
+export interface IThumbnailCardProps {
+  postId: string;
+  postThumbnailPath: string;
+  title: string;
+  createDate: string;
+  latitude?: string;
+  longitude?: string;
+}
+
+export interface IMainSidebarProps {
+  coupleData: ICoupleProfileProps;
+  postList: IThumbnailCardProps[];
+}
+
+export interface IMainPageTemplateProps extends IMainSidebarProps {
+  coordinate: {
+    latitude: number;
+    longitude: number;
+  };
+}


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷

UI적으로 변경된 것은 없어서 해당 코드 부분 복사하여 올립니다.
```js
import { ImageProps } from 'next/image';

export interface ICoupleUserProps {
  profileImagePath: string | null;
  nickName: string;
}

export interface IStartDateProps {
  startDate: string;
}

export interface ICoupleProfileProps extends IStartDateProps {
  me: ICoupleUserProps;
  you: ICoupleUserProps;
}

export interface IThumbnailCardProps {
  postId: string;
  postThumbnailPath: string;
  title: string;
  createDate: string;
  latitude?: string;
  longitude?: string;
}

export interface IMainSidebarProps {
  coupleData: ICoupleProfileProps;
  postList: IThumbnailCardProps[];
}

export interface IMainPageTemplateProps extends IMainSidebarProps {
  coordinate: {
    latitude: number;
    longitude: number;
  };
}
```
### 내용

메인페이지에서 사용되던 types를 추상화하여 모두 types/mainPage.d.ts에 넣어놓았습니다.
이로써 cycle과 코드 반복 안녕 ✨

<br>

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

f5cd034ac0246bd2ffa334e0b12f94bb8246b2fc : types 추상화
28270faeff58b3e093fd71efda073f9bc70f9b03 : props에 맞추어 jsx명 수정

<br>

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

사실 types를 따로 정리한 것은 이번이 처음이라 많이 미숙할 수 있습니다.
다른분들 type 파일 작성하신 것 보고 따라 했는데요,
혹시 이상하거나 더 나은 코드가 있다면 주저없이 말씀 해 주세요~ 

<br>


### 🚀 연관된 이슈

WOOR-211

<br>