### PR TITLE
WOOR-232/맵 로딩 버그 수정

### DIFF
--- a/components/atoms/Map/Map.tsx
+++ b/components/atoms/Map/Map.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Script from 'next/script';
 import { Map as KakaoMap, MapProps } from 'react-kakao-maps-sdk';
 
 interface IProps extends MapProps {
@@ -36,19 +35,14 @@ function Map({ children, isMain, width, height, ...props }: IProps) {
   }, []);
 
   return (
-    <>
-      <Script src={URL} onLoad={onLoad} />
-      {loaded && (
-        <KakaoMap
-          style={
-            isMain ? defaultStyle : { ...defaultStyle, borderRadius: '8px' }
-          }
-          {...props}
-        >
-          {children}
-        </KakaoMap>
-      )}
-    </>
+    loaded && (
+      <KakaoMap
+        style={isMain ? defaultStyle : { ...defaultStyle, borderRadius: '8px' }}
+        {...props}
+      >
+        {children}
+      </KakaoMap>
+    )
   );
 }
 

--- a/components/atoms/Map/Map.tsx
+++ b/components/atoms/Map/Map.tsx
@@ -34,16 +34,14 @@ function Map({ children, isMain, width, height, ...props }: IProps) {
     };
   }, []);
 
-  return (
-    loaded && (
-      <KakaoMap
-        style={isMain ? defaultStyle : { ...defaultStyle, borderRadius: '8px' }}
-        {...props}
-      >
-        {children}
-      </KakaoMap>
-    )
-  );
+  return loaded ? (
+    <KakaoMap
+      style={isMain ? defaultStyle : { ...defaultStyle, borderRadius: '8px' }}
+      {...props}
+    >
+      {children}
+    </KakaoMap>
+  ) : null;
 }
 
 export default Map;

--- a/components/atoms/Map/Map.tsx
+++ b/components/atoms/Map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Script from 'next/script';
 import { Map as KakaoMap, MapProps } from 'react-kakao-maps-sdk';
 
@@ -24,6 +24,16 @@ function Map({ children, isMain, width, height, ...props }: IProps) {
     height,
     ...props.style,
   };
+
+  useEffect(() => {
+    const $script = document.createElement('script');
+    $script.src = URL;
+    $script.addEventListener('load', onLoad);
+    document.head.appendChild($script);
+    return () => {
+      $script.remove();
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- next/link 또는 next/router로 클라이언트 사이드로 이동 시 맵이 나타나지 않는 버그를 수정합니다.

### 스크린 샷

### 내용

기존 next의 `<Script/>` 태그는 첫 로딩시에만 onLoad 이벤트가 발생하기 때문에, useEffect로 맵이 마운트 시 script 태그가 생기고, unmount 시 script 태그를 삭제하는 방식을 사용합니다.


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 테스트 해보고 이상 있을 시 꼭 문의 주세요!

### 🚀 연관된 이슈

WOOR-232
