### PR TITLE
WOOR-235/PostDetail Page API 연결

### DIFF
--- a/apis/post.ts
+++ b/apis/post.ts
@@ -1,6 +1,5 @@
 import { AxiosInstance } from 'axios';
-import LocalStorage from 'utils/storage';
-import { IPostFormState, ITag } from 'types';
+import { IPostFormState, IPostDetailProps } from 'types';
 import { IApiResponse } from 'types/api';
 
 interface IPostWriteProps {
@@ -26,7 +25,7 @@ export function createPost({ data, instance }: IPostWriteProps) {
 
 export function updatePost({ instance, data, id }: IPostWriteProps) {
   const res = instance
-    .put(`/couples/posts/${id}`, data)
+    .put<IApiResponse<object>>(`/couples/posts/${id}`, data)
     .then((response) => {
       return response.data;
     })
@@ -41,7 +40,7 @@ export function updatePost({ instance, data, id }: IPostWriteProps) {
 
 export function getOnePost({ instance, id }: IPostWriteProps) {
   const res = instance
-    .get(`/couples/posts/${id}`)
+    .get<IApiResponse<IPostDetailProps>>(`/couples/posts/${id}`)
     .then((response) => {
       return response.data.data;
     })
@@ -54,47 +53,17 @@ export function getOnePost({ instance, id }: IPostWriteProps) {
   return res;
 }
 
-export async function updatePost({ instance, data, id }: IPostWriteProps) {
+export function deletePost({ instance, id }: IPostWriteProps) {
   const response = instance
-    .put(`/couples/posts/${id}`, data)
+    .delete<IApiResponse<object>>(`/couples/posts/${id}`)
     .then((res) => {
-      return res.data;
+      return res.data.data;
     })
     .catch((error) => {
-      const responseWithError = error.response;
+      const res = error.response;
 
-      return responseWithError.data;
+      throw Error(res.message);
     });
 
   return response;
-}
-
-export async function getOnePost({ instance, id }: IPostWriteProps) {
-  try {
-    const response = await instance.get<IApiResponse<IPostDetailProps>>(
-      `/couples/posts/${id}`,
-    );
-
-    const { data } = response.data;
-
-    return data;
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
-}
-
-export async function deletePost({ instance, id }: IPostWriteProps) {
-  try {
-    const response = await instance.delete<IApiResponse<object>>(
-      `/couples/posts/${id}`,
-    );
-
-    const { data } = response.data;
-
-    return data;
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
 }

--- a/apis/post.ts
+++ b/apis/post.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios';
-import { IPostFormState } from 'types';
+import LocalStorage from 'utils/storage';
+import { IPostFormState, ITag } from 'types';
 import { IApiResponse } from 'types/api';
 
 interface IPostWriteProps {
@@ -52,3 +53,66 @@ export function getOnePost({ instance, id }: IPostWriteProps) {
 
   return res;
 }
+
+export const updatePost = async ({ instance, data, id }: IPostWriteProps) => {
+  const accessToken = LocalStorage.getItem('accessToken', '');
+
+  const response = instance
+    .put(`/couples/posts/${id}`, data, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    .then((res) => {
+      return res.data;
+    })
+    .catch((error) => {
+      const { response: res } = error;
+
+      return res?.data;
+    });
+
+  return response;
+};
+
+export const getOnePost = async ({ instance, id }: IPostWriteProps) => {
+  const accessToken = LocalStorage.getItem('accessToken', '');
+  try {
+    const res = await instance.get<IApiResponse<IPostDetailProps>>(
+      `/couples/posts/${id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    const { data } = res.data;
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const deletePost = async ({ instance, id }: IPostWriteProps) => {
+  const accessToken = LocalStorage.getItem('accessToken', '');
+  try {
+    const res = await instance.delete<IApiResponse<object>>(
+      `/couples/posts/${id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    const { data } = res.data;
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/apis/post.ts
+++ b/apis/post.ts
@@ -54,65 +54,47 @@ export function getOnePost({ instance, id }: IPostWriteProps) {
   return res;
 }
 
-export const updatePost = async ({ instance, data, id }: IPostWriteProps) => {
-  const accessToken = LocalStorage.getItem('accessToken', '');
-
+export async function updatePost({ instance, data, id }: IPostWriteProps) {
   const response = instance
-    .put(`/couples/posts/${id}`, data, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
+    .put(`/couples/posts/${id}`, data)
     .then((res) => {
       return res.data;
     })
     .catch((error) => {
-      const { response: res } = error;
+      const responseWithError = error.response;
 
-      return res?.data;
+      return responseWithError.data;
     });
 
   return response;
-};
+}
 
-export const getOnePost = async ({ instance, id }: IPostWriteProps) => {
-  const accessToken = LocalStorage.getItem('accessToken', '');
+export async function getOnePost({ instance, id }: IPostWriteProps) {
   try {
-    const res = await instance.get<IApiResponse<IPostDetailProps>>(
+    const response = await instance.get<IApiResponse<IPostDetailProps>>(
       `/couples/posts/${id}`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
     );
 
-    const { data } = res.data;
+    const { data } = response.data;
 
     return data;
   } catch (error) {
     console.error(error);
     return null;
   }
-};
+}
 
-export const deletePost = async ({ instance, id }: IPostWriteProps) => {
-  const accessToken = LocalStorage.getItem('accessToken', '');
+export async function deletePost({ instance, id }: IPostWriteProps) {
   try {
-    const res = await instance.delete<IApiResponse<object>>(
+    const response = await instance.delete<IApiResponse<object>>(
       `/couples/posts/${id}`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
     );
 
-    const { data } = res.data;
+    const { data } = response.data;
 
     return data;
   } catch (error) {
     console.error(error);
     return null;
   }
-};
+}

--- a/components/molecules/TagInputWithList/TagInputWithList.tsx
+++ b/components/molecules/TagInputWithList/TagInputWithList.tsx
@@ -57,7 +57,7 @@ export function TagInputWithList({
         return Promise.reject(error);
       }
     };
-    console.log(getAllTags());
+    getAllTags();
   }, [instance]);
 
   const handleEnterType = (newTagName: string) => {

--- a/components/organisms/PostBody/PostBody.styles.tsx
+++ b/components/organisms/PostBody/PostBody.styles.tsx
@@ -32,6 +32,7 @@ export const Date = styled.h6`
 export const PostControl = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 `;
 
 export const EditPostButton = styled(Button)`
@@ -41,10 +42,11 @@ export const EditPostButton = styled(Button)`
   font-size: 20px;
 `;
 
-export const DeletePostLink = styled.a`
-  margin-top: 1rem;
+export const DeletePostButton = styled(Button)`
+  width: 100%;
+  border: none;
   font-size: 1rem;
-  color: ${({ theme }) => theme.colors.gray};
+  color: #2c91ea;
   text-align: right;
 `;
 

--- a/components/organisms/PostBody/PostBody.tsx
+++ b/components/organisms/PostBody/PostBody.tsx
@@ -25,6 +25,11 @@ export function PostBody({
 }: IPostBodyProps) {
   const [deleteConfirm, setDeleteConfirm] = useState<boolean>(false);
 
+  const handleEditClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    handleEdit();
+  };
+
   const handleDeleteClick = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     if (!deleteConfirm) {
@@ -42,7 +47,7 @@ export function PostBody({
           <S.Date>{date}</S.Date>
         </S.TitleLine>
         <S.PostControl>
-          <S.EditPostButton size="small" onClick={handleEdit}>
+          <S.EditPostButton size="small" onClick={handleEditClick}>
             포스트 편집
           </S.EditPostButton>
           <S.DeletePostButton size="small" onClick={handleDeleteClick}>

--- a/components/organisms/PostBody/PostBody.tsx
+++ b/components/organisms/PostBody/PostBody.tsx
@@ -1,6 +1,6 @@
 import { TagList } from 'components/molecules/TagList';
 import { ITag, ICoordinates } from 'types';
-import Link from 'next/link';
+import { useState } from 'react';
 
 import * as S from './PostBody.styles';
 
@@ -10,7 +10,8 @@ interface IPostBodyProps {
   tagList: ITag[];
   content: string;
   location: ICoordinates;
-  postId: string;
+  handleEdit: () => void;
+  handleDelete: () => void;
 }
 
 export function PostBody({
@@ -19,8 +20,20 @@ export function PostBody({
   tagList,
   content,
   location,
-  postId,
+  handleEdit,
+  handleDelete,
 }: IPostBodyProps) {
+  const [deleteConfirm, setDeleteConfirm] = useState<boolean>(false);
+
+  const handleDeleteClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    if (!deleteConfirm) {
+      setDeleteConfirm(true);
+      return;
+    }
+    handleDelete();
+  };
+
   return (
     <S.Container>
       <S.Header>
@@ -29,10 +42,12 @@ export function PostBody({
           <S.Date>{date}</S.Date>
         </S.TitleLine>
         <S.PostControl>
-          <Link href={`/post/write/${postId}`}>
-            <S.EditPostButton size="small">포스트 편집</S.EditPostButton>
-          </Link>
-          <S.DeletePostLink>포스트 삭제</S.DeletePostLink>
+          <S.EditPostButton size="small" onClick={handleEdit}>
+            포스트 편집
+          </S.EditPostButton>
+          <S.DeletePostButton size="small" onClick={handleDeleteClick}>
+            {deleteConfirm ? '삭제 확인' : '포스트 삭제'}
+          </S.DeletePostButton>
         </S.PostControl>
       </S.Header>
       <S.PostTags>

--- a/components/organisms/PostBody/PostBody.tsx
+++ b/components/organisms/PostBody/PostBody.tsx
@@ -1,5 +1,6 @@
 import { TagList } from 'components/molecules/TagList';
 import { ITag, ICoordinates } from 'types';
+import Link from 'next/link';
 
 import * as S from './PostBody.styles';
 
@@ -9,6 +10,7 @@ interface IPostBodyProps {
   tagList: ITag[];
   content: string;
   location: ICoordinates;
+  postId: string;
 }
 
 export function PostBody({
@@ -17,6 +19,7 @@ export function PostBody({
   tagList,
   content,
   location,
+  postId,
 }: IPostBodyProps) {
   return (
     <S.Container>
@@ -26,7 +29,9 @@ export function PostBody({
           <S.Date>{date}</S.Date>
         </S.TitleLine>
         <S.PostControl>
-          <S.EditPostButton size="small">포스트 편집</S.EditPostButton>
+          <Link href={`/post/write/${postId}`}>
+            <S.EditPostButton size="small">포스트 편집</S.EditPostButton>
+          </Link>
           <S.DeletePostLink>포스트 삭제</S.DeletePostLink>
         </S.PostControl>
       </S.Header>

--- a/components/organisms/PostBody/PostBody.tsx
+++ b/components/organisms/PostBody/PostBody.tsx
@@ -25,12 +25,12 @@ export function PostBody({
 }: IPostBodyProps) {
   const [deleteConfirm, setDeleteConfirm] = useState<boolean>(false);
 
-  const handleEditClick = (e: React.MouseEvent<HTMLElement>) => {
+  const handleEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     handleEdit();
   };
 
-  const handleDeleteClick = (e: React.MouseEvent<HTMLElement>) => {
+  const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (!deleteConfirm) {
       setDeleteConfirm(true);

--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -82,6 +82,7 @@ export default function PostDetail() {
           tagList={tagList}
           content={content}
           location={location}
+          postId={id}
         />
       }
     />

--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -27,10 +27,11 @@ export default function PostDetail() {
       if (!router.isReady) return;
 
       try {
-        const res = await getOnePost({ instance, id });
+        const response = await getOnePost({ instance, id });
 
-        if (res) {
-          const { title, datingDate, tags, content, location, imageUrls } = res;
+        if (response) {
+          const { title, datingDate, tags, content, location, imageUrls } =
+            response;
           const newPost: IPostInfo = {
             title,
             date: datingDate,

--- a/pages/post/write/[id]/index.tsx
+++ b/pages/post/write/[id]/index.tsx
@@ -7,7 +7,6 @@ import {
   IPostValidationState,
   IPostValidationProps,
   IInitialPostState,
-  IPostDetailProps,
 } from 'types';
 import { postValidation, parsePostData, postInitialValue } from 'utils';
 import { updatePost, getOnePost } from 'apis/post';
@@ -44,10 +43,10 @@ export default function PostEdit() {
       if (!router.isReady) return;
 
       try {
-        const res = (await getOnePost({
+        const res = await getOnePost({
           instance: axiosInstance,
           id,
-        })) as IPostDetailProps;
+        });
 
         if (res) {
           setAllState(parsePostData({ postData: res }) as IInitialPostState);


### PR DESCRIPTION
## 📌 PR 설명

#### 해당 PR은 WOOR-231 에서 만들어진 API 함수를 재사용합니다.

따라서 231번 merge 후 api 부분이 달라질 예정입니다.

- DetailPage에 단건 조회, 삭제 API 를 붙이고 페이지 이동 기능을 추가했습니다. 
- WOOR-231이 아직 머지되지 않아 Edit 버튼을 누르면 404가 나옵니다. 

### 스크린 샷

![2022-08-11 22-59-52 (1)](https://user-images.githubusercontent.com/53640976/184154600-6a4f8e8d-855a-4471-8237-24ea2e6b4e7d.gif)

### 내용

- 단건 조회
    - CSR 로 게시물을 불러옵니다. 
    - 조회 결과 해당 게시물이 없으면 404 페이지로 이동합니다. 
- 삭제
    - 삭제 확인으로 별도의 창을 띄우기보다는 한번 text가 바뀝니다. 
    - 삭제 api 호출과 동시에 홈화면으로 이동합니다. 

## ✔️ PR 포인트 & 궁금한 점

- CSR로 하고있지만, 초기 로딩이 좀 느린데 이 부분을 개선할 수 있는지 궁금합니다. 
- 그 밖의 개선가능한 점 환영합니다!

### 🚀 연관된 이슈

WOOR-235