### PR TITLE
WOOR-237/메인페이지 포스트 생성 페이지로의 라우팅

### DIFF
--- a/components/templates/MainPageTemplate/MainPageTemplate.styles.ts
+++ b/components/templates/MainPageTemplate/MainPageTemplate.styles.ts
@@ -23,7 +23,6 @@ export const MapContainer = styled.div`
 
 export const OverlayContainer = styled.div``;
 
-// 새글 생성 버튼의 포지션을 위해 생성한 스타일 컴포넌트.
 export const ButtonContainer = styled.div`
   z-index: 500;
   position: absolute;

--- a/components/templates/MainPageTemplate/MainPageTemplate.styles.ts
+++ b/components/templates/MainPageTemplate/MainPageTemplate.styles.ts
@@ -22,3 +22,12 @@ export const MapContainer = styled.div`
 `;
 
 export const OverlayContainer = styled.div``;
+
+// 새글 생성 버튼의 포지션을 위해 생성한 스타일 컴포넌트.
+export const ButtonContainer = styled.div`
+  z-index: 500;
+  position: absolute;
+  bottom: 3rem;
+  right: 3rem;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.5);
+`;

--- a/components/templates/MainPageTemplate/MainPageTemplate.tsx
+++ b/components/templates/MainPageTemplate/MainPageTemplate.tsx
@@ -58,15 +58,12 @@ export function MainPageTemplate({
           ))}
         </Map>
       </S.MapContainer>
-      {/* 새 글 생성 버튼 컴포넌트 */}
       <Link href="/post/write" passHref>
-        {/* <a href="#!"> */}
         <S.ButtonContainer>
           <Button variant="blackOutlined" size="large">
             새 글 생성
           </Button>
         </S.ButtonContainer>
-        {/* </a> */}
       </Link>
     </S.Container>
   );

--- a/components/templates/MainPageTemplate/MainPageTemplate.tsx
+++ b/components/templates/MainPageTemplate/MainPageTemplate.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
+import Link from 'next/link';
+import { Button, Map, MapMarkerOverlay, MainSidebar } from 'components';
 import { IMainPageTemplateProps } from 'types';
-import { Map, MapMarkerOverlay, MainSidebar } from 'components';
 import { MapMarker } from 'react-kakao-maps-sdk';
 import * as S from './MainPageTemplate.styles';
 
@@ -57,6 +58,16 @@ export function MainPageTemplate({
           ))}
         </Map>
       </S.MapContainer>
+      {/* 새 글 생성 버튼 컴포넌트 */}
+      <Link href="/post/write">
+        <a href="#!">
+          <S.ButtonContainer>
+            <Button variant="blackOutlined" size="large">
+              새 글 생성
+            </Button>
+          </S.ButtonContainer>
+        </a>
+      </Link>
     </S.Container>
   );
 }

--- a/components/templates/MainPageTemplate/MainPageTemplate.tsx
+++ b/components/templates/MainPageTemplate/MainPageTemplate.tsx
@@ -59,14 +59,14 @@ export function MainPageTemplate({
         </Map>
       </S.MapContainer>
       {/* 새 글 생성 버튼 컴포넌트 */}
-      <Link href="/post/write">
-        <a href="#!">
-          <S.ButtonContainer>
-            <Button variant="blackOutlined" size="large">
-              새 글 생성
-            </Button>
-          </S.ButtonContainer>
-        </a>
+      <Link href="/post/write" passHref>
+        {/* <a href="#!"> */}
+        <S.ButtonContainer>
+          <Button variant="blackOutlined" size="large">
+            새 글 생성
+          </Button>
+        </S.ButtonContainer>
+        {/* </a> */}
       </Link>
     </S.Container>
   );


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/97934878/184297538-75f40b11-de49-46c8-ba43-d373c6ed030b.png">


### 내용

# 이보다 짧은 PR은 없다

제곧내

생각해보니 새 글 생성하는 플로우가 없더군요. 그래서 후딱 만들었습니다.

메인페이지에서의 새 글 생성 버튼 및 포스트 생성 페이지로의 라우팅을 구현하였습니다.
21줄이면 신기록이군요 핱핱 부담없이 읽으시죠!

<br>


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

그냥 라우팅 보내기만 하면 될까요?
메인페이지에서 포스트 생성 페이지로 넘어갈 때 해줘야 하는 추가 작업이 있을까요
적극적인 의견 매우 환영합니다 :3

<br>

### 🚀 연관된 이슈

WOOR-237

<br>
<br>