### PR TITLE
WOOR-258/Header에 LogoLink, Logout, 프사 받기 기능 추가

### DIFF
--- a/components/molecules/LoggedInSection/LoggedInSection.stories.tsx
+++ b/components/molecules/LoggedInSection/LoggedInSection.stories.tsx
@@ -7,5 +7,5 @@ export default {
 } as ComponentMeta<typeof LoggedInSection>;
 
 export const Default: ComponentStory<typeof LoggedInSection> = () => {
-  return <LoggedInSection />;
+  return <LoggedInSection handleLogout={() => {}} />;
 };

--- a/components/molecules/LoggedInSection/LoggedInSection.tsx
+++ b/components/molecules/LoggedInSection/LoggedInSection.tsx
@@ -1,15 +1,32 @@
 import { Button, Profile } from 'components';
+import Link from 'next/link';
 import * as S from './LoggedInSection.styles';
 
-export function LoggedInSection() {
-  const onLogout = () => console.log('logout');
+interface ILoggedInSectionProps {
+  isSignedIn: boolean;
+  profileImageSrc?: string | null;
+}
 
+export function LoggedInSection({
+  isSignedIn,
+  profileImageSrc,
+}: ILoggedInSectionProps) {
   return (
     <S.Container>
-      <Button size="small" variant="blackOutlined" onClick={onLogout}>
-        log out
-      </Button>
-      <Profile width={48} height={48} isLink />
+      {isSignedIn ? (
+        <>
+          <Button size="small" variant="blackOutlined">
+            Log Out
+          </Button>
+          <Profile path={profileImageSrc} width={48} height={48} isLink />
+        </>
+      ) : (
+        <Link href="/auth/signin">
+          <Button size="small" variant="blackOutlined">
+            Log In
+          </Button>
+        </Link>
+      )}
     </S.Container>
   );
 }

--- a/components/molecules/LoggedInSection/LoggedInSection.tsx
+++ b/components/molecules/LoggedInSection/LoggedInSection.tsx
@@ -1,32 +1,21 @@
 import { Button, Profile } from 'components';
-import Link from 'next/link';
 import * as S from './LoggedInSection.styles';
 
 interface ILoggedInSectionProps {
-  isSignedIn: boolean;
   profileImageSrc?: string | null;
+  handleLogout: () => void;
 }
 
 export function LoggedInSection({
-  isSignedIn,
   profileImageSrc,
+  handleLogout,
 }: ILoggedInSectionProps) {
   return (
     <S.Container>
-      {isSignedIn ? (
-        <>
-          <Button size="small" variant="blackOutlined">
-            Log Out
-          </Button>
-          <Profile path={profileImageSrc} width={48} height={48} isLink />
-        </>
-      ) : (
-        <Link href="/auth/signin">
-          <Button size="small" variant="blackOutlined">
-            Log In
-          </Button>
-        </Link>
-      )}
+      <Button size="small" variant="blackOutlined" onClick={handleLogout}>
+        Log Out
+      </Button>
+      <Profile path={profileImageSrc} width={48} height={48} isLink />
     </S.Container>
   );
 }

--- a/components/molecules/LoggedInSection/LoggedInSection.tsx
+++ b/components/molecules/LoggedInSection/LoggedInSection.tsx
@@ -15,7 +15,12 @@ export function LoggedInSection({
       <Button size="small" variant="blackOutlined" onClick={handleLogout}>
         Log Out
       </Button>
-      <Profile path={profileImageSrc} width={48} height={48} isLink />
+      <Profile
+        path={profileImageSrc && profileImageSrc}
+        width={48}
+        height={48}
+        isLink
+      />
     </S.Container>
   );
 }

--- a/components/organisms/NavBar/NavBar.tsx
+++ b/components/organisms/NavBar/NavBar.tsx
@@ -3,11 +3,34 @@ import Link from 'next/link';
 import { LoggedInSection } from 'components';
 import mainLogo from 'public/image/main-logo.svg';
 import userState from 'core';
-import { useRecoilValueAfterMount } from 'hooks';
+import { useAxiosInstance, useRecoilValueAfterMount } from 'hooks';
+import { useSetRecoilState } from 'recoil';
+import { useRouter } from 'next/router';
 import * as S from './NavBar.styles';
 
 export function NavBar() {
   const user = useRecoilValueAfterMount(userState, null);
+  const setUser = useSetRecoilState(userState);
+  const instance = useAxiosInstance();
+  const router = useRouter();
+
+  const logout = async () => {
+    try {
+      await instance.post('/auth/signout');
+      setUser(null);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.push('auth/signin');
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   return (
     <S.Container>
@@ -22,8 +45,8 @@ export function NavBar() {
           />
         </Link>
         <LoggedInSection
-          isSignedIn={user !== null}
           profileImageSrc={user && user.imageUrl}
+          handleLogout={handleLogout}
         />
       </S.Wrapper>
     </S.Container>

--- a/components/organisms/NavBar/NavBar.tsx
+++ b/components/organisms/NavBar/NavBar.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { LoggedInSection } from 'components';
 import mainLogo from 'public/image/main-logo.svg';
 import * as S from './NavBar.styles';
@@ -7,7 +8,15 @@ export function NavBar() {
   return (
     <S.Container>
       <S.Wrapper>
-        <Image src={mainLogo} alt="main-logo" width={240} height={40} />
+        <Link href="/">
+          <Image
+            src={mainLogo}
+            style={{ cursor: 'pointer' }}
+            alt="main-logo"
+            width={240}
+            height={40}
+          />
+        </Link>
         <LoggedInSection />
       </S.Wrapper>
     </S.Container>

--- a/components/organisms/NavBar/NavBar.tsx
+++ b/components/organisms/NavBar/NavBar.tsx
@@ -2,9 +2,13 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { LoggedInSection } from 'components';
 import mainLogo from 'public/image/main-logo.svg';
+import userState from 'core';
+import { useRecoilValueAfterMount } from 'hooks';
 import * as S from './NavBar.styles';
 
 export function NavBar() {
+  const user = useRecoilValueAfterMount(userState, null);
+
   return (
     <S.Container>
       <S.Wrapper>
@@ -17,7 +21,10 @@ export function NavBar() {
             height={40}
           />
         </Link>
-        <LoggedInSection />
+        <LoggedInSection
+          isSignedIn={user !== null}
+          profileImageSrc={user && user.imageUrl}
+        />
       </S.Wrapper>
     </S.Container>
   );


### PR DESCRIPTION
## 📌 PR 설명

![258 시연](https://user-images.githubusercontent.com/53640976/184367134-900b5956-3077-40e5-a792-a243b2a39fef.gif)

- Header 의 기본 기능 3가지를 구현했습니다. 
    1. 로고를 눌렀을 때 `'/'` 으로 이동
    2. 사용자의 프로필 이미지를 전시
    3. 로그아웃 버튼을 눌렀을 때 로그아웃과 동시에 SignIn 페이지로 이동
