### PR TITLE
WOOR-271/카카오 api 에러 처리

### DIFF
--- a/hooks/useMapSearch/useMapSearch.ts
+++ b/hooks/useMapSearch/useMapSearch.ts
@@ -45,6 +45,10 @@ function useMapSearch({ initialMarker, map }: IMapSearchProps): IReturnType {
   const getSearchResults = useCallback(
     (keyword: string) => {
       if (!services) return;
+      if (keyword === '') {
+        setMarkers([]);
+        return;
+      }
 
       services.keywordSearch(keyword, (data, status) => {
         if (status !== kakao.maps.services.Status.OK) {


### PR DESCRIPTION
## 📌 PR 설명

- [X] 에러 수정

### 스크린 샷

![화면 기록 2022-08-13 오후 12 53 06](https://user-images.githubusercontent.com/60822846/184467457-57bcafc7-b99e-4943-922c-559d146f3b58.gif)


### 내용

빈 문자열을 입력했을 때, 에러가 콘솔에 출력되는 것을 변경하였습니다.

```javascript
  const getSearchResults = useCallback(
    (keyword: string) => {
      if (!services) return;
      // 빈문자열이면
      if (keyword === '') {
       // 상태값 초기화 하고 리턴
        setMarkers([]);
        return;
      }

      services.keywordSearch(keyword, (data, status) => {
    .....
    },
    [services, setBounds],
  );
```

## 💻 요구 사항과 구현 내용

0ce11123fd8ff040a7b0b4e0649b48713580b373 카카오맵 에러 처리

## ✔️ PR 포인트 & 궁금한 점



### 🚀 연관된 이슈

[WOOR-271](https://amabnb.atlassian.net/browse/WOOR-271?atlOrigin=eyJpIjoiZjI4YTVhYjUxOTA4NGNlNWExYzFmNmUxNzYzNTdhZWIiLCJwIjoiaiJ9)
