### PR TITLE
WOOR-272/TagInput에 '\' 입력시 오류 출력 해결

### DIFF
--- a/components/molecules/TagInput/TagInput.tsx
+++ b/components/molecules/TagInput/TagInput.tsx
@@ -15,7 +15,11 @@ export function TagInput({ allTags, onEnterType, ...props }: ITagInputProps) {
   const [options, setOptions] = useState<ITag[]>([]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newInputValue = e.target.value;
+    let newInputValue = e.target.value;
+    if (newInputValue.slice(-1) === '\\') {
+      newInputValue = newInputValue.slice(0, -1);
+      return;
+    }
     if (newInputValue.length > 10) return;
     if (newInputValue.length === 0) {
       setOptions([]);


### PR DESCRIPTION
TagInput 의 입력란 마지막에 `\` 를 입력하지 못하는 규칙을 추가했습니다. 정규표현식을 다시 짜기에는 시간이 좀 모자른 것 같아서 일단 막아두었읍니다. setValue 로 동작하기 때문에 복붙과 같은 상황에도 대응할 수 있습니다. 