### PR TITLE
WOOR-280/withNoAuthRoute 구현

### DIFF
--- a/hocs/index.ts
+++ b/hocs/index.ts
@@ -1,3 +1,4 @@
 export { default as withLoading } from './withLoading';
 export { default as withAuthRoute } from './withAuthRoute';
 export { default as withCoupleRoute } from './withCoupleRoute';
+export { default as withNoAuthRoute } from './withNoAuthRoute';

--- a/hocs/index.ts
+++ b/hocs/index.ts
@@ -1,4 +1,4 @@
 export { default as withLoading } from './withLoading';
 export { default as withAuthRoute } from './withAuthRoute';
 export { default as withCoupleRoute } from './withCoupleRoute';
-export { default as withNoAuthRoute } from './withNoAuthRoute';
+export { default as withSigninSignout } from './withSigninSignout';

--- a/hocs/withNoAuthRoute.tsx
+++ b/hocs/withNoAuthRoute.tsx
@@ -1,0 +1,30 @@
+import { FunctionComponent, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useComponentDidMount, useRecoilValueAfterMount } from 'hooks';
+import userState from 'core';
+
+/**
+ * NOTE: 해당 HOC는 auth/signin, auth/signup 등
+ * 로그인 하지 않은 페이지에서만 사용할 것
+ */
+function withNoAuth<P>(Component: FunctionComponent<P>) {
+  return function WithAuthComponent(props: P) {
+    const mounted = useComponentDidMount();
+    const user = useRecoilValueAfterMount(userState, null);
+    const router = useRouter();
+
+    useEffect(() => {
+      if (!mounted) return;
+      if (user && !user.isCouple) {
+        router.push('/profile');
+        return;
+      }
+      router.push('/');
+    }, [mounted, router, user]);
+
+    if (!(mounted && !user)) return null;
+    return <Component {...props} />;
+  };
+}
+
+export default withNoAuth;

--- a/hocs/withSigninSignout.tsx
+++ b/hocs/withSigninSignout.tsx
@@ -7,7 +7,7 @@ import userState from 'core';
  * NOTE: 해당 HOC는 auth/signin, auth/signup 등
  * 로그인 하지 않은 페이지에서만 사용할 것
  */
-function withNoAuth<P>(Component: FunctionComponent<P>) {
+function witihSigninSignout<P>(Component: FunctionComponent<P>) {
   return function WithAuthComponent(props: P) {
     const mounted = useComponentDidMount();
     const user = useRecoilValueAfterMount(userState, null);
@@ -27,4 +27,4 @@ function withNoAuth<P>(Component: FunctionComponent<P>) {
   };
 }
 
-export default withNoAuth;
+export default witihSigninSignout;

--- a/hocs/withSigninSignout.tsx
+++ b/hocs/withSigninSignout.tsx
@@ -15,11 +15,11 @@ function witihSigninSignout<P>(Component: FunctionComponent<P>) {
 
     useEffect(() => {
       if (!mounted) return;
-      if (user && !user.isCouple) {
-        router.push('/profile');
+      if (user && user.isCouple) {
+        router.push('/');
         return;
       }
-      router.push('/');
+      router.push('/profile');
     }, [mounted, router, user]);
 
     if (!(mounted && !user)) return null;

--- a/pages/auth/signin/index.tsx
+++ b/pages/auth/signin/index.tsx
@@ -13,6 +13,7 @@ import { LoginFormDataTypes, ILoginResponse } from 'types/auth';
 import { IApiResponse } from 'types/api';
 import LocalStorage from 'utils/storage';
 import userState from 'core';
+import withNoAuth from 'hocs/withNoAuthRoute';
 
 type LoginFormKeyType = 'email' | 'password';
 
@@ -113,4 +114,4 @@ function Signin() {
   );
 }
 
-export default Signin;
+export default withNoAuth(Signin);

--- a/pages/auth/signin/index.tsx
+++ b/pages/auth/signin/index.tsx
@@ -13,7 +13,7 @@ import { LoginFormDataTypes, ILoginResponse } from 'types/auth';
 import { IApiResponse } from 'types/api';
 import LocalStorage from 'utils/storage';
 import userState from 'core';
-import withNoAuth from 'hocs/withNoAuthRoute';
+import { withSigninSignout } from 'hocs';
 
 type LoginFormKeyType = 'email' | 'password';
 
@@ -114,4 +114,4 @@ function Signin() {
   );
 }
 
-export default withNoAuth(Signin);
+export default withSigninSignout(Signin);

--- a/pages/auth/signup/index.tsx
+++ b/pages/auth/signup/index.tsx
@@ -1,8 +1,8 @@
 import { SignUpTemplate } from 'components';
-import withNoAuth from 'hocs/withNoAuthRoute';
+import { withSigninSignout } from 'hocs';
 
 function SignUp() {
   return <SignUpTemplate />;
 }
 
-export default withNoAuth(SignUp);
+export default withSigninSignout(SignUp);

--- a/pages/auth/signup/index.tsx
+++ b/pages/auth/signup/index.tsx
@@ -1,7 +1,8 @@
 import { SignUpTemplate } from 'components';
+import withNoAuth from 'hocs/withNoAuthRoute';
 
 function SignUp() {
   return <SignUpTemplate />;
 }
 
-export default SignUp;
+export default withNoAuth(SignUp);


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
`/auth/signin`, `/auth/signup`에서 사용할, 사용자가 이미 로그인 했거나 커플일 경우 다른 페이지로 이동하도록 하는 Router를 구현하였습니다.

커플일 경우는 테스트를 했는데, 로그인을 했지만 커플이 아닐 경우에는 테스트를 못해봐서, 해당 부분 테스트해주시면 감사하겠습니다.


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [feat: withNoAuthRoute 구현](https://github.com/prgrms-web-devcourse/Team_02_WooriMap_FE/commit/423551b549c1507892cfb80df92b590b53ec9b50)

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->]
- 테스트 후 이상현상 발생 시 제보 부탁드립니다. 빠른 시일 내에 고치겠습니당

### 🚀 연관된 이슈
WOOR-280