### PR TITLE
WOOR-290/지도 클릭을 통해 마커 처리

### DIFF
--- a/components/molecules/SearchableMap/SearchableMap.tsx
+++ b/components/molecules/SearchableMap/SearchableMap.tsx
@@ -65,6 +65,18 @@ export function SearchableMap({
           isMain={false}
           onCreate={setMap}
           center={{ ...initialMapCenter }}
+          onClick={(_t, mouseEvent) => {
+            const postion: ICoordinates = {
+              latitude: mouseEvent.latLng.getLat(),
+              longitude: mouseEvent.latLng.getLng(),
+            };
+            const content = '';
+
+            onClickMarker()({
+              position: postion,
+              content,
+            });
+          }}
         >
           <MultiMarkerDrawer markers={markers} onClick={onClickMarker()} />
         </Map>


### PR DESCRIPTION
## 📌 PR 설명

- [X] 지도를 클릭하여 마커를 표시한다.

### 스크린 샷

![화면 기록 2022-08-15 오전 12 28 18](https://user-images.githubusercontent.com/60822846/184544248-dbfd96bb-9c9e-4edc-b168-c49c2877ed02.gif)


### 내용

@mrbartrns 요청으로 지도 클릭을 통한 마커 추가 기능을 넣었습니다!

## ✔️ PR 포인트 & 궁금한 점

+ 엣지 케이스가 있나요?

### 🚀 연관된 이슈

[WOOR-290](https://amabnb.atlassian.net/browse/WOOR-290?atlOrigin=eyJpIjoiMTNlODU0OTQyYjNkNDE1ZmE0NWMxZTFkNWIxNTY3ODQiLCJwIjoiaiJ9)
