### PR TITLE
WOOR-304/postContent 의 Line Break 미적용 문제 수정

### DIFF
--- a/components/organisms/PostBody/PostBody.styles.tsx
+++ b/components/organisms/PostBody/PostBody.styles.tsx
@@ -106,11 +106,14 @@ export const DeletePostButton = styled(Button)`
   }
 `;
 
-export const PostContent = styled.pre`
+export const PostContent = styled.div`
   flex-grow: 1;
 
   font-size: 0.8rem;
   line-height: 1.7rem;
+
+  white-space: pre-wrap;
+  word-wrap: break-word;
 
   overflow: auto;
 `;

--- a/components/organisms/PostBody/PostBody.styles.tsx
+++ b/components/organisms/PostBody/PostBody.styles.tsx
@@ -106,7 +106,7 @@ export const DeletePostButton = styled(Button)`
   }
 `;
 
-export const PostContent = styled.div`
+export const PostContent = styled.pre`
   flex-grow: 1;
 
   font-size: 0.8rem;


### PR DESCRIPTION
## 📌 PR 설명

상세 페이지의 내용 영역이 엔터키가 적용이 안되던 문제를 해결하였습니다.

PostContent 영역의 태그를 div에서 pre로 변경했습니다. 이제 엔터키도 반영이 잘 됩니다.

### 스크린 샷

![image](https://user-images.githubusercontent.com/53640976/184559439-eefef149-bc37-4a31-a28b-7ec6e4b29d26.png)


## 💻 요구 사항과 구현 내용

## ✔️ PR 포인트 & 궁금한 점

### 🚀 연관된 이슈

WOOR-304