### PR TITLE
WOOR-296/메타 태그 컴포넌트 구현

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -36,6 +36,7 @@ export { Dropdown, DropdownItem } from 'components/molecules/Dropdown';
 export { ProfileUpload } from 'components/molecules/ProfileUpload';
 export { Toast } from 'components/molecules/Toast';
 export { TagList } from 'components/molecules/TagList';
+export { MetaTag } from 'components/molecules/MetaTag';
 
 // organisms
 export { LoggedInSection } from 'components/molecules/LoggedInSection';

--- a/components/molecules/MetaTag/MetaTag.tsx
+++ b/components/molecules/MetaTag/MetaTag.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+interface IMetaTag {
+  title: string;
+}
+
+/**
+ * ANCHOR: 추후 og:image나 og:title 등 메타 테그를 추가할 수 있다.
+ */
+function MetaTag({ title }: IMetaTag) {
+  return (
+    <Head>
+      <title>{title}</title>
+      <link rel="shortcut icon" href="/favicon.ico" />
+    </Head>
+  );
+}
+
+export default MetaTag;

--- a/components/molecules/MetaTag/index.ts
+++ b/components/molecules/MetaTag/index.ts
@@ -1,0 +1,1 @@
+export { default as MetaTag } from './MetaTag';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,26 +1,20 @@
-import Head from 'next/head';
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from '@emotion/react';
 import { RecoilRoot } from 'recoil';
-import { Layout } from 'components';
+import { Layout, MetaTag } from 'components';
 import { GlobalStyle, theme } from '../styles';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <>
-      <Head>
-        <title>WooriMap</title>
-        <link rel="shortcut icon" href="/favicon.ico" />
-      </Head>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <RecoilRoot>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </RecoilRoot>
-      </ThemeProvider>
-    </>
+    <ThemeProvider theme={theme}>
+      <MetaTag title="우리맵" />
+      <GlobalStyle />
+      <RecoilRoot>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </RecoilRoot>
+    </ThemeProvider>
   );
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { MainPageTemplate } from 'components';
+import { MainPageTemplate, MetaTag } from 'components';
 import { useAxiosInstance, useGeolocation } from 'hooks';
 import {
   IApiResponse,
@@ -151,12 +151,15 @@ function Home() {
   }, [postFilter]);
 
   return (
-    <MainPageTemplate
-      coupleData={coupleData}
-      postList={postList || []}
-      coordinate={{ latitude: lat, longitude: lng }}
-      handlePostFilter={handlePostFilter}
-    />
+    <>
+      <MetaTag title="우리맵 메인 페이지" />
+      <MainPageTemplate
+        coupleData={coupleData}
+        postList={postList || []}
+        coordinate={{ latitude: lat, longitude: lng }}
+        handlePostFilter={handlePostFilter}
+      />
+    </>
   );
 }
 export default withCoupleRoute(Home);


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷

### 내용

- 각 페이지에서 사용할 수 있는 메타 태그 묶음을 구현했습니다
- 구현은 간단하며, 추후 og:title이나 og:image 등 seo에 필요한 메타 태그들을 묶어 사용할 수 있습니다. 
- 현재는 title만 입력이 가능하며, 각 페이지에서 MetaTag를 불러와 title을 붙여넣을 수 있습니다.

```tsx
// _app.tsx
function MyApp({ Component, pageProps }: AppProps) {
  return (
    <ThemeProvider theme={theme}>
      <MetaTag title="우리맵" />
      <GlobalStyle />
      <RecoilRoot>
        <Layout>
          <Component {...pageProps} />
        </Layout>
      </RecoilRoot>
    </ThemeProvider>
  );
}

```

```tsx
// pages/index.tsx

function Home() {
// ...
  return (
    <>
      <MetaTag title="우리맵 메인 페이지" />
      <MainPageTemplate
        coupleData={coupleData}
        postList={postList || []}
        coordinate={{ latitude: lat, longitude: lng }}
        handlePostFilter={handlePostFilter}
      />
    </>
  );
}

```

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [feat: 각 페이지에서 사용할 수 있는 메타태그 구현](https://github.com/prgrms-web-devcourse/Team_02_WooriMap_FE/commit/604dd1cb02b23222424f07db9d212d4aa5a55e2b)

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### 🚀 연관된 이슈
