### PR TITLE
WOOR-297/내비게이션 바 렌더링 문제 수정

### DIFF
--- a/components/organisms/NavBar/NavBar.stories.tsx
+++ b/components/organisms/NavBar/NavBar.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { NavBar } from './NavBar';
+import NavBar from './NavBar';
 
 export default {
   title: 'Components/Molecules/NavBar',

--- a/components/organisms/NavBar/NavBar.tsx
+++ b/components/organisms/NavBar/NavBar.tsx
@@ -7,7 +7,7 @@ import { useAxiosInstance, useRecoilValueAfterMount } from 'hooks';
 import { useSetRecoilState } from 'recoil';
 import * as S from './NavBar.styles';
 
-export function NavBar() {
+function NavBar() {
   const user = useRecoilValueAfterMount(userState, null);
   const setUser = useSetRecoilState(userState);
   const instance = useAxiosInstance();
@@ -43,3 +43,5 @@ export function NavBar() {
     </S.Container>
   );
 }
+
+export default NavBar;

--- a/components/organisms/NavBar/index.ts
+++ b/components/organisms/NavBar/index.ts
@@ -1,1 +1,1 @@
-export { NavBar } from './NavBar';
+export { default as NavBar } from './NavBar';

--- a/components/templates/Layout/Layout.tsx
+++ b/components/templates/Layout/Layout.tsx
@@ -1,16 +1,15 @@
 import { NavBar } from 'components';
-import { useRouter } from 'next/router';
+import { useRecoilValueAfterMount } from 'hooks';
+import userState from 'core';
 import * as S from './Layout.styles';
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  const { asPath } = useRouter();
-
-  const isAuthPage = asPath.includes('/signin') || asPath.includes('/signup');
+  const user = useRecoilValueAfterMount(userState, null);
 
   return (
     <S.PageContainer>
       <S.Container>
-        {!isAuthPage && <NavBar />}
+        {user && <NavBar />}
         <S.Wrapper>{children}</S.Wrapper>
       </S.Container>
     </S.PageContainer>


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷
![simulation](https://user-images.githubusercontent.com/56826914/184569696-c369045f-3c9d-465d-977a-04fd5b17003e.gif)


### 내용

- 내비게이션 바의 렌더링 문제를 수정합니다.

기존 페이지에 라우팅 처리를 했지만, 내비게이션 바는 Layout 내부에 위치해있어 withRoute에 영향을 받지 않아, 내비게이션 바가 먼저 뜨는 현상이 존재했습니다.  
또한, 기존 내비게이션 바 출현 조건이 path로 설정되어 있어, 해당 path를 제외하면 내비게이션 바가 먼저 뜨는 현상이 있었습니다.(대표적으로 메인페이지에서 로그아웃 시) 따라서 현재 내비게이션 바 출현 조건을 user 객체가 존재하는 경우로 변경하였습니다 (현재는 로그인 한 사람만 내비게이션 바를 볼 수 있으므로).

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- [fix: 처음 로딩 시 내비게이션 바만 보이는 현상](https://github.com/prgrms-web-devcourse/Team_02_WooriMap_FE/commit/c3981983516d452e2da7f9cce2b909058c673aae)

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 출현 조건을 변경했을 때 나타날 수 있는 문제점?

### 🚀 연관된 이슈
WOOR-297