### PR TITLE
WOOR-320/인풋 엔터로 제출 할 수 없는 TextInput에 preventDefatult 추가

### DIFF
--- a/components/molecules/TagInput/TagInput.stories.tsx
+++ b/components/molecules/TagInput/TagInput.stories.tsx
@@ -33,6 +33,7 @@ export const Default: ComponentStory<typeof TagInput> = () => {
   return (
     <Wrapper>
       <TagInput
+        onKeyPress={() => {}}
         key="1"
         onEnterType={(a: string) => {
           console.log(a);

--- a/components/molecules/TagInput/TagInput.tsx
+++ b/components/molecules/TagInput/TagInput.tsx
@@ -8,9 +8,15 @@ interface ITagInputProps
   allTags: ITag[];
   onEnterType: (newTagName: string) => void;
   onClickButton: (e?: React.MouseEvent<HTMLImageElement>) => void;
+  onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-export function TagInput({ allTags, onEnterType, ...props }: ITagInputProps) {
+export function TagInput({
+  allTags,
+  onEnterType,
+  onKeyPress,
+  ...props
+}: ITagInputProps) {
   const [inputValue, setInputValue] = useState<string>('');
   const [options, setOptions] = useState<ITag[]>([]);
 
@@ -51,6 +57,7 @@ export function TagInput({ allTags, onEnterType, ...props }: ITagInputProps) {
         onKeyUp={handleComplete}
         hasOption={options.length > 0}
         autoComplete="off"
+        onKeyPress={onKeyPress}
         {...props}
       />
       {options.length > 0 && (

--- a/components/molecules/TagInputWithList/TagInputWithList.stories.tsx
+++ b/components/molecules/TagInputWithList/TagInputWithList.stories.tsx
@@ -14,6 +14,7 @@ const handleChange: HandleChangeTypes = ({ name, value }) => {
 export const Default: ComponentStory<typeof TagInputWithList> = () => {
   return (
     <TagInputWithList
+      onKeyPress={() => {}}
       text="태그"
       key="태그"
       onClickButton={() => {}}

--- a/components/molecules/TagInputWithList/TagInputWithList.tsx
+++ b/components/molecules/TagInputWithList/TagInputWithList.tsx
@@ -26,6 +26,7 @@ export function TagInputWithList({
   value,
   handleChange,
   onClickButton,
+  onKeyPress,
   ...props
 }: ITagInputWithListProps) {
   const [inputValue, setInputValue] = useState<ITag[]>(
@@ -96,6 +97,7 @@ export function TagInputWithList({
         allTags={allTags}
         onEnterType={handleEnterType}
         onClickButton={handleClickButton}
+        onKeyPress={onKeyPress}
         {...props}
       />
       <S.SelectedTags tagList={inputValue} onDelete={handleDelete} />

--- a/components/molecules/TagInputWithList/TagInputWithList.tsx
+++ b/components/molecules/TagInputWithList/TagInputWithList.tsx
@@ -8,6 +8,7 @@ import * as S from './TagInputWithList.styles';
 interface ITagInputWithListProps extends ITextInputProps {
   value?: ITag[] | string;
   onClickButton: (e?: React.MouseEvent<HTMLImageElement>) => void;
+  onKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const defaultTagColors: string[] = [

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -15,7 +15,7 @@ export function TextInput({
   value,
   onClickButton,
   handleChange,
-  onKeyPress = () => {},
+  onKeyPress,
   ...props
 }: ITextInputProps) {
   return (

--- a/components/molecules/TextInput/TextInput.tsx
+++ b/components/molecules/TextInput/TextInput.tsx
@@ -8,18 +8,21 @@ interface ITextInputProps
   value: string | Array<ITag>;
   onClickButton: (e?: React.MouseEvent<HTMLImageElement>) => void;
   handleChange?: HandleChangeTypes;
+  onKeyPress?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export function TextInput({
   value,
   onClickButton,
   handleChange,
+  onKeyPress = () => {},
   ...props
 }: ITextInputProps) {
   return (
     <S.TextInputWrapper>
       <S.TextInput
         value={value as string}
+        onKeyPress={onKeyPress}
         onChange={(e) => handleChange?.({ e })}
         {...props}
       />

--- a/components/molecules/TextInputWithLabel/TextInputWithLabel.tsx
+++ b/components/molecules/TextInputWithLabel/TextInputWithLabel.tsx
@@ -15,6 +15,12 @@ export function TextInputWithLabel(props: ITextInputWithLabelProps) {
     if (deleteAll && name) deleteAll(name);
   };
 
+  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  };
+
   return (
     <S.Container>
       <S.Wrapper
@@ -27,6 +33,7 @@ export function TextInputWithLabel(props: ITextInputWithLabelProps) {
             value={value as string}
             onClickButton={onClickDeleteButton}
             handleChange={handleChange as HandleChangeTypes}
+            onKeyPress={onKeyPress}
             {...props}
           />
         )}
@@ -50,6 +57,7 @@ export function TextInputWithLabel(props: ITextInputWithLabelProps) {
             value={value as ITag[]}
             onClickButton={onClickDeleteButton}
             handleChange={handleChange as HandleChangeTypes}
+            onKeyPress={onKeyPress}
             {...props}
           />
         )}


### PR DESCRIPTION
## 📌 PR 설명

- [X] 제출 막기 

### 내용

```javascript
interface ITextInputProps
  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
  ....
  onKeyPress?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
}

export function TextInput({
  ....
  onKeyPress = () => {},
  ...props
}: ITextInputProps) {
  return (
    <S.TextInputWrapper>
      <S.TextInput
        value={value as string}
        onKeyPress={onKeyPress}
        onChange={(e) => handleChange?.({ e })}
        {...props}
      />
   ....
    </S.TextInputWrapper>
  );
}
```

onKeyPress를 선택적으로 받게 해서 제출을 막아야 하는 것은 onKeyPress을 받도록 했습니다.

### 🚀 연관된 이슈

[WOOR-320](https://amabnb.atlassian.net/browse/WOOR-320?atlOrigin=eyJpIjoiYWY4YWI2YmEyNmEyNGViZDljNDJkYzM1ZDcyYTM3MWUiLCJwIjoiaiJ9)
