### PR TITLE
WOOR-324/withCoupleRoute 조건 추가

### DIFF
--- a/components/organisms/CoupleInviteForm/CoupleInviteForm.styles.ts
+++ b/components/organisms/CoupleInviteForm/CoupleInviteForm.styles.ts
@@ -141,3 +141,13 @@ export const Back = styled.span`
 
   cursor: pointer;
 `;
+
+export const Error = styled.span`
+  width: 100%;
+  height: fit-content;
+
+  text-align: center;
+  color: ${({ theme }) => theme.colors.alert};
+
+  font-size: 0.7rem;
+`;

--- a/components/organisms/CoupleInviteForm/CoupleInviteForm.tsx
+++ b/components/organisms/CoupleInviteForm/CoupleInviteForm.tsx
@@ -17,7 +17,7 @@ interface ICoupleInviteFormProps extends ITextInputProps {
 export function CoupleInviteForm({ code }: ICoupleInviteFormProps) {
   const router = useRouter();
   const [inputCode, setInputCode] = useState<string>('');
-  const [error, setError] = useState<string>('ㄴㅇ');
+  const [error, setError] = useState<string>('');
   const setUser = useSetRecoilState(userState);
   const instance = useAxiosInstance();
 

--- a/components/organisms/CoupleInviteForm/CoupleInviteForm.tsx
+++ b/components/organisms/CoupleInviteForm/CoupleInviteForm.tsx
@@ -17,7 +17,7 @@ interface ICoupleInviteFormProps extends ITextInputProps {
 export function CoupleInviteForm({ code }: ICoupleInviteFormProps) {
   const router = useRouter();
   const [inputCode, setInputCode] = useState<string>('');
-  const [error, setError] = useState<string>('');
+  const [error, setError] = useState<string>('ㄴㅇ');
   const setUser = useSetRecoilState(userState);
   const instance = useAxiosInstance();
 
@@ -62,16 +62,19 @@ export function CoupleInviteForm({ code }: ICoupleInviteFormProps) {
     }
   };
 
-  const onChange = (e: ChangeEvent<HTMLInputElement>) =>
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInputCode(e.target.value);
+    setError('');
+  };
 
-  const onClickDeleteButton = () => setInputCode('');
+  const onClickDeleteButton = () => {
+    setInputCode('');
+    setError('');
+  };
 
   const onSubmit = (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
   };
-
-  console.error(error);
 
   return (
     <S.CoupleInviteFormBackground onSubmit={onSubmit}>
@@ -106,6 +109,8 @@ export function CoupleInviteForm({ code }: ICoupleInviteFormProps) {
             커플 맺음 확인하기
           </S.InviteConfrimButton>
         </S.InviteButtonWrapper>
+
+        <S.Error>{error && error}</S.Error>
 
         <Link href="/profile">
           <S.Back>프로필 페이지로 돌아가기</S.Back>

--- a/hocs/withCoupleRoute.tsx
+++ b/hocs/withCoupleRoute.tsx
@@ -28,16 +28,14 @@ function withCoupleRoute<P>(Component: FunctionComponent<P>) {
       }
     }, [mounted, pathname, router, user]);
 
-    if (user !== null) {
-      // 커플이 아니고 path가 invite일 때
-      if (!user.isCouple && pathname === '/profile/invite') {
-        return <Component {...props} />;
-      }
+    // 커플이 아니고 path가 invite일 때
+    if (!user?.isCouple && pathname === '/profile/invite') {
+      return <Component {...props} />;
+    }
 
-      // 커플이고 path가 invite가 아닐때, ( path 체크를 안해주면 중간에 들어갔다 나옵니다.. )
-      if (user.isCouple && pathname !== '/profile/invite') {
-        return <Component {...props} />;
-      }
+    // 커플이고 path가 invite가 아닐때, ( path 체크를 안해주면 중간에 들어갔다 나옵니다.. )
+    if (user?.isCouple && pathname !== '/profile/invite') {
+      return <Component {...props} />;
     }
 
     return null;

--- a/hocs/withCoupleRoute.tsx
+++ b/hocs/withCoupleRoute.tsx
@@ -28,7 +28,18 @@ function withCoupleRoute<P>(Component: FunctionComponent<P>) {
       }
     }, [mounted, pathname, router, user]);
 
-    if (user?.isCouple) return <Component {...props} />;
+    if (user !== null) {
+      // 커플이 아니고 path가 invite일 때
+      if (!user.isCouple && pathname === '/profile/invite') {
+        return <Component {...props} />;
+      }
+
+      // 커플이고 path가 invite가 아닐때, ( path 체크를 안해주면 중간에 들어갔다 나옵니다.. )
+      if (user.isCouple && pathname !== '/profile/invite') {
+        return <Component {...props} />;
+      }
+    }
+
     return null;
   };
 }


### PR DESCRIPTION
## 📌 PR 설명

- [X] withCoupleRoute 조건 추가

### 스크린 샷

#### 솔로일때

![화면 기록 2022-08-16 오후 12 13 19](https://user-images.githubusercontent.com/60822846/184790696-d6ec35f3-de48-4935-83c6-be5fcb7b7b01.gif)

#### 커플일때

![화면 기록 2022-08-16 오후 12 14 50](https://user-images.githubusercontent.com/60822846/184790949-604e2892-97b0-4875-91e2-aaa50d46b980.gif)

### 내용

#### withCoupleRoute 수정

```javascript
if (user?.isCouple) return <Component {...props} />;
```

위 조건만 추가되어, 확인해보니 솔로일때 invite 페이지로 들어가지 못하는 상황을 발견하였습니다.

따라서, 아래와 같이 조건을 추가하였습니다.

```javascript
    if (user !== null) {
      // 커플이 아니고 path가 invite일 때
      if (!user.isCouple && pathname === '/profile/invite') {
        return <Component {...props} />;
      }

      // 커플이고 path가 invite가 아닐때, ( path 체크를 안해주면 중간에 들어갔다 나옵니다.. )
      if (user.isCouple && pathname !== '/profile/invite') {
        return <Component {...props} />;
      }
    }
```

위와같이 path를 일일히 체크하는 이유는 커플일때, 접근하지 못하는 페이지는 `profile/invite`이기 때문입니다..


## 💻 요구 사항과 구현 내용

94065b988b91165909ceaa517e67c00091b6845c withCoupleRoute 수정

## ✔️ PR 포인트 & 궁금한 점

- 엣지 케이스가 있나요?
- 더 깔끔하게 변경할 수 있나요? ( 일단 급하게 했습니다 ㅠㅠ )

### 🚀 연관된 이슈

[WOOR-324](https://amabnb.atlassian.net/browse/WOOR-324?atlOrigin=eyJpIjoiZDdiZGU5Y2ZlY2E5NDUyZmE5ZDc3NzUwNDM4ZmRlYmEiLCJwIjoiaiJ9)
