### PR TITLE
WOOR-326/Navigation Bar 렌더링 이슈 수정

### DIFF
--- a/components/organisms/NavBar/NavBar.tsx
+++ b/components/organisms/NavBar/NavBar.tsx
@@ -16,9 +16,10 @@ function NavBar() {
   const logout = async () => {
     try {
       await instance.post('/auth/signout');
-      setUser(null);
     } catch (error) {
-      console.error(error);
+      // do nothing
+    } finally {
+      setUser(null);
     }
   };
 
@@ -26,7 +27,7 @@ function NavBar() {
     try {
       await logout();
     } catch (error) {
-      console.error(error);
+      // do nothing
     }
   };
 

--- a/components/templates/Layout/Layout.tsx
+++ b/components/templates/Layout/Layout.tsx
@@ -1,15 +1,9 @@
-import { NavBar } from 'components';
-import { useRecoilValueAfterMount } from 'hooks';
-import userState from 'core';
 import * as S from './Layout.styles';
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  const user = useRecoilValueAfterMount(userState, null);
-
   return (
     <S.PageContainer>
       <S.Container>
-        {user && <NavBar />}
         <S.Wrapper>{children}</S.Wrapper>
       </S.Container>
     </S.PageContainer>

--- a/hocs/withAuthRoute.tsx
+++ b/hocs/withAuthRoute.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useComponentDidMount, useRecoilValueAfterMount } from 'hooks';
 import userState from 'core';
+import { NavBar } from 'components';
 
 /**
  * NOTE: 해당 HOC를 /auth 주소에서 사용하면 무한 루프로 인해
@@ -20,7 +21,15 @@ function withAuth<P>(Component: FunctionComponent<P>) {
       }
     }, [mounted, router, user]);
 
-    if (user) return <Component {...props} />;
+    if (user) {
+      return (
+        <>
+          <NavBar />
+          <Component {...props} />
+        </>
+      );
+    }
+
     return null;
   };
 }

--- a/hocs/withCoupleRoute.tsx
+++ b/hocs/withCoupleRoute.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useComponentDidMount, useRecoilValueAfterMount } from 'hooks';
 import userState from 'core';
+import { NavBar } from 'components';
 
 function withCoupleRoute<P>(Component: FunctionComponent<P>) {
   return function WithCoupleComponent(props: P) {
@@ -35,7 +36,12 @@ function withCoupleRoute<P>(Component: FunctionComponent<P>) {
 
     // 커플이고 path가 invite가 아닐때, ( path 체크를 안해주면 중간에 들어갔다 나옵니다.. )
     if (user?.isCouple && pathname !== '/profile/invite') {
-      return <Component {...props} />;
+      return (
+        <>
+          <NavBar />
+          <Component {...props} />
+        </>
+      );
     }
 
     return null;


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 스크린 샷

### 내용

- Navigation Bar가 페이지 로딩 후 항상 떠있어, 페이지 이동 시 어색하게 렌더링 되는 부분을 수정합니다.
- 로그아웃 로직을 개선합니다.

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [fix: 로그아웃 로직 개선](https://github.com/prgrms-web-devcourse/Team_02_WooriMap_FE/commit/c9584f4419296c9b3f8f942bd6814da151355a17)
- [fix: navigation bar를 HOC 내부로 이동](https://github.com/prgrms-web-devcourse/Team_02_WooriMap_FE/pull/103/commits/b18f4d29db5ad9370ee9ac54ef6f486f341903ec)


## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### 🚀 연관된 이슈
